### PR TITLE
Add test script and debugging function

### DIFF
--- a/examples/basic/basic.ino
+++ b/examples/basic/basic.ino
@@ -554,7 +554,7 @@ char memory_read(int address)
 //
 // TODO: Proper bounds-checking.
 //
-void memory_write(int address, byte value)
+void memory_write(int address, char value)
 {
     int a = address - RAM_START;
 

--- a/examples/hello-debug/hello-debug.ino
+++ b/examples/hello-debug/hello-debug.ino
@@ -8,13 +8,14 @@
 //
 
 //
-// You can see how it runs with additional debug message if you un-comment the line below in the
-// z80retroshield.h header file in your library folder.
-//
-// "#define Z80RetroShield_DEBUG" 
+// You can see how it runs with additional debug message by following steps below,
+// 1. Use Z80RetroShieldDebug instance instead of z80retroshield
+// 2. Set debug_output callback
+// 3. Set some debug flags by calling enable_debug()
 // 
 
 #include <z80retroshield.h>
+#include <z80retroshieldDebug.h>
 
 //
 // Our program, as hex.
@@ -33,7 +34,7 @@ int memory_len = sizeof(memory) / sizeof(memory[0]);
 //
 // Our helper
 //
-Z80RetroShield cpu;
+Z80RetroShieldDebug cpu;
 
 //
 // RAM I/O function handler.
@@ -69,6 +70,7 @@ void setup()
 {
     Serial.begin(115200);
     while (!Serial);
+    delay(1000);
 
     //
     // Setup callbacks.
@@ -122,8 +124,7 @@ void loop()
     //
     // We stop running after running a specific number of cycles
     //
-    if (cycles > 4096)
-    //if (cycles > 64)
+    if (cycles > 200)
     {
         Serial.print("Z80 processor stopped ");
         Serial.print(cycles);

--- a/examples/hello-debug/hello-debug.ino
+++ b/examples/hello-debug/hello-debug.ino
@@ -1,0 +1,144 @@
+//
+// This sketch uses code on the Z80 to write a greeting to the serial-console.
+//
+// We let this program run for a few thousand cycles, which should be
+// sufficient to allow the text-output, "Hello\n", to complete.
+//
+// Steve
+//
+
+//
+// You can see how it runs with additional debug message if you un-comment the line below in the
+// z80retroshield.h header file in your library folder.
+//
+// "#define Z80RetroShield_DEBUG" 
+// 
+
+#include <z80retroshield.h>
+
+//
+// Our program, as hex.
+//
+// The source code is located in `hello.z80`.
+//
+unsigned char memory[32] =
+{
+    0x3e, 0x48, 0xd3, 0x01, 0x3e, 0x65, 0xd3, 0x01, 0x3e, 0x6c, 0xd3, 0x01,
+    0xd3, 0x01, 0x3e, 0x6f, 0xd3, 0x01, 0x3e, 0x0a, 0xd3, 0x01, 0xc3, 0x16,
+    0x00
+};
+int memory_len = sizeof(memory) / sizeof(memory[0]);
+
+
+//
+// Our helper
+//
+Z80RetroShield cpu;
+
+//
+// RAM I/O function handler.
+//
+char memory_read(int address)
+{
+    return (memory[address]);
+}
+
+
+//
+// I/O function handler.
+//
+void io_write(int address, char byte)
+{
+    if (address == 1)
+        Serial.write(byte);
+}
+
+
+//
+// Debug message handler.
+//
+void debug_output(const char* msg) {
+    Serial.println(msg);
+}
+
+
+//
+// Setup routine: Called once.
+//
+void setup()
+{
+    Serial.begin(115200);
+    while (!Serial);
+
+    //
+    // Setup callbacks.
+    //
+    // We must setup a memory-read callback, otherwise the program
+    // won't be fetched and executed.
+    //
+    cpu.set_memory_read(memory_read);
+
+    //
+    // Then we setup a callback to be executed every time an "out (x),y"
+    // instruction is encountered.
+    //
+    cpu.set_io_write(io_write);
+
+    //
+    // Enable debug output.
+    //
+    cpu.set_debug_output(debug_output);
+
+    //
+    // Configured.
+    //
+    Serial.println("Z80 configured; launching program.");
+}
+
+
+//
+// Loop function: Called forever.
+//
+void loop()
+{
+    //
+    // We stop running after a specific number of cycles
+    //
+    // Have we reached that point?
+    //
+    static bool done = false;
+
+    //
+    // Count the number of times we've pumped the Z80.
+    //
+    static int cycles = 0;
+
+    //
+    // Are we done?  If so return.
+    //
+    if (done)
+        return;
+
+    //
+    // We stop running after running a specific number of cycles
+    //
+    if (cycles > 4096)
+    //if (cycles > 64)
+    {
+        Serial.print("Z80 processor stopped ");
+        Serial.print(cycles);
+        Serial.println(" cycles executed.");
+        done = true;
+        return;
+    }
+
+    //
+    // Step the CPU.
+    //
+    cpu.Tick();
+
+    //
+    // We've run a tick.
+    //
+    cycles++;
+}

--- a/examples/hello-debug/hello-debug.ino
+++ b/examples/hello-debug/hello-debug.ino
@@ -50,8 +50,11 @@ char memory_read(int address)
 //
 void io_write(int address, char byte)
 {
-    if (address == 1)
+    if (address == 1) {
         Serial.write(byte);
+        // Display characters one by one because you get so many debug output
+        Serial.println();
+    }
 }
 
 
@@ -90,6 +93,8 @@ void setup()
     // Enable debug output.
     //
     cpu.set_debug_output(debug_output);
+    cpu.enable_debug(cpu.DEBUG_FLAG_IO);
+    cpu.enable_debug(cpu.DEBUG_FLAG_MEM);
 
     //
     // Configured.
@@ -124,7 +129,7 @@ void loop()
     //
     // We stop running after running a specific number of cycles
     //
-    if (cycles > 200)
+    if (cycles > 150)
     {
         Serial.print("Z80 processor stopped ");
         Serial.print(cycles);

--- a/examples/monitor/monitor.ino
+++ b/examples/monitor/monitor.ino
@@ -59,7 +59,7 @@ char memory_read(int address)
 //
 // RAM I/O function handler.
 //
-void memory_write(int address, byte value)
+void memory_write(int address, char value)
 {
     if (address >= 0 && address < memory_len)
         memory[address] = value;

--- a/examples/speed_test/speed_test.ino
+++ b/examples/speed_test/speed_test.ino
@@ -67,14 +67,14 @@ void loop()
     //
     // Step the CPU, and count it.
     //
-    cpu.Tick();
-    cycles++;
+    cpu.Tick(100);
+    cycles += 100;
 
 
     if (currentMillis - lastMillis > 1000)
     {
         Serial.print("Cycles per second second:");
-        Serial.println(cycles);
+        Serial.println(cycles*1000/(currentMillis - lastMillis));
 
         lastMillis = currentMillis;
         cycles = 0;

--- a/examples/speed_test/speed_test.ino
+++ b/examples/speed_test/speed_test.ino
@@ -59,7 +59,7 @@ void loop()
     // Static variables.
     //
     static long lastMillis = 0;
-    static int cycles = 0;
+    static long cycles = 0;
 
     long currentMillis = millis();
 

--- a/examples/uc/uc.ino
+++ b/examples/uc/uc.ino
@@ -67,7 +67,7 @@ void io_write(int address, char byte)
         return;
     }
 
-    return 0;
+    return;
 }
 
 

--- a/src/z80retroshield.cpp
+++ b/src/z80retroshield.cpp
@@ -76,7 +76,7 @@ Z80RetroShieldClassName::Z80RetroShieldClassName()
     m_on_io_read = NULL;
     m_on_io_write = NULL;
     m_debug_output = NULL;
-    m_debug = false;
+    m_debug = 0;
     m_cycle = 0;
 
     //
@@ -109,19 +109,31 @@ Z80RetroShieldClassName::~Z80RetroShieldClassName()
 {
 }
 
-void Z80RetroShieldClassName::show_status(const char* header) {
-    if (m_debug_output) {
-        char buf[100];
-        sprintf(buf, "%s%4ld addr=%04x data=%04x ~MREQ=%s ~IOREQ=%s  RW=%s",
+void Z80RetroShieldClassName::show_status(const char* header)
+{
+    if (m_debug_output == nullptr) {
+        return;
+    }
+    char buf[100];
+    uint8_t mreq_n = STATE_MREQ_N();
+    uint8_t iorq_n = STATE_IORQ_N();
+    if ((m_debug & DEBUG_FLAG_CYCLE) ||
+        (m_debug & DEBUG_FLAG_IO) && iorq_n == 0 ||
+        (m_debug & DEBUG_FLAG_MEM) && mreq_n == 0) {
+        sprintf(buf, "%s%4ld addr=%04x data=%02x ~MREQ=%s ~IOREQ=%s  RW=%s",
                 header,
                 m_cycle,
                 ADDR(),
                 DATA_IN(),
-                STATE_MREQ_N() ? "H" : "L",
-                STATE_IORQ_N() ? "H" : "L",
+                mreq_n ? "H" : "L",
+                iorq_n ? "H" : "L",
                 STATE_RD_N() ? "" : "R",
                 STATE_WR_N() ? "" : "W");
         m_debug_output(buf);
+    } else {
+        return;
+    }
+    if (m_debug & DEBUG_FLAG_VERBOSE) {
 #ifdef ADAFRUIT_GRAND_CENTRAL_M4
         uint32_t dataa = PORT->Group[PGA].IN.reg;
         uint32_t datab = PORT->Group[PGB].IN.reg;
@@ -144,7 +156,7 @@ void Z80RetroShieldClassName::show_status(const char* header) {
         sprintf(buf, "DIR   PA: %08X  PB: %08X  PC: %08X  PD: %08X",
                 dira, dirb, dirc, dird);
         m_debug_output(buf);
-#endif
+#endif  // ADAFRUIT_GRAND_CENTRAL_M4
     }
 }
 

--- a/src/z80retroshield.cpp
+++ b/src/z80retroshield.cpp
@@ -66,7 +66,7 @@ static inline void ADDR_L_DIR(uint8_t dir) { DDRA = dir; }
 /*
  * Constructor
  */
-Z80RetroShield::Z80RetroShield()
+Z80RetroShieldClassName::Z80RetroShieldClassName()
 {
     //
     // Callbacks are all empty by default.
@@ -105,11 +105,11 @@ Z80RetroShield::Z80RetroShield()
 /*
  * Destructor
  */
-Z80RetroShield::~Z80RetroShield()
+Z80RetroShieldClassName::~Z80RetroShieldClassName()
 {
 }
 
-void Z80RetroShield::show_status(const char* header) {
+void Z80RetroShieldClassName::show_status(const char* header) {
     if (m_debug_output) {
         char buf[100];
         sprintf(buf, "%s%4ld addr=%04x data=%04x ~MREQ=%s ~IOREQ=%s  RW=%s",
@@ -153,7 +153,7 @@ void Z80RetroShield::show_status(const char* header) {
  *
  * This will step the processor by a single clock-tick.
  */
-void Z80RetroShield::Tick()
+void Z80RetroShieldClassName::Tick()
 {
     /*
      * The memory address we're reading/writing to.
@@ -247,7 +247,7 @@ tick_tock:
  * This will run the clock a few cycles to ensure that the processor
  * is reset fully.
  */
-void Z80RetroShield::Reset()
+void Z80RetroShieldClassName::Reset()
 {
     // Drive RESET conditions
     digitalWrite(uP_RESET_N, LOW);

--- a/src/z80retroshield.cpp
+++ b/src/z80retroshield.cpp
@@ -75,6 +75,9 @@ Z80RetroShield::Z80RetroShield()
     m_on_memory_write = NULL;
     m_on_io_read = NULL;
     m_on_io_write = NULL;
+    m_debug_output = NULL;
+    m_debug = false;
+    m_cycle = 0;
 
     //
     // Set directions
@@ -104,6 +107,45 @@ Z80RetroShield::Z80RetroShield()
  */
 Z80RetroShield::~Z80RetroShield()
 {
+}
+
+void Z80RetroShield::show_status(const char* header) {
+    if (m_debug_output) {
+        char buf[100];
+        sprintf(buf, "%s%4ld addr=%04x data=%04x ~MREQ=%s ~IOREQ=%s  RW=%s",
+                header,
+                m_cycle,
+                ADDR(),
+                DATA_IN(),
+                STATE_MREQ_N() ? "H" : "L",
+                STATE_IORQ_N() ? "H" : "L",
+                STATE_RD_N() ? "" : "R",
+                STATE_WR_N() ? "" : "W");
+        m_debug_output(buf);
+#ifdef ADAFRUIT_GRAND_CENTRAL_M4
+        uint32_t dataa = PORT->Group[PGA].IN.reg;
+        uint32_t datab = PORT->Group[PGB].IN.reg;
+        uint32_t datac = PORT->Group[PGC].IN.reg;
+        uint32_t datad = PORT->Group[PGD].IN.reg;
+        sprintf(buf, "IN    PA: %08X  PB: %08X  PC: %08X  PD: %08X",
+                dataa, datab, datac, datad);
+        m_debug_output(buf);
+        uint32_t outa = PORT->Group[PGA].OUT.reg;
+        uint32_t outb = PORT->Group[PGB].OUT.reg;
+        uint32_t outc = PORT->Group[PGC].OUT.reg;
+        uint32_t outd = PORT->Group[PGD].OUT.reg;
+        sprintf(buf, "OUT   PA: %08X  PB: %08X  PC: %08X  PD: %08X",
+                outa, outb, outc, outd);
+        m_debug_output(buf);
+        uint32_t dira = PORT->Group[PGA].DIR.reg;
+        uint32_t dirb = PORT->Group[PGB].DIR.reg;
+        uint32_t dirc = PORT->Group[PGC].DIR.reg;
+        uint32_t dird = PORT->Group[PGD].DIR.reg;
+        sprintf(buf, "DIR   PA: %08X  PB: %08X  PC: %08X  PD: %08X",
+                dira, dirb, dirc, dird);
+        m_debug_output(buf);
+#endif
+    }
 }
 
 /*
@@ -143,9 +185,11 @@ void Z80RetroShield::Tick()
                 DATA_OUT(m_on_memory_read(uP_ADDR));
             else
                 DATA_OUT(0);
+            debug_show_status("MEMR: ");
         }
         else if (!STATE_WR_N())
         {
+            debug_show_status("MEMW: ");
             // RAM write
             if (m_on_memory_write != NULL)
                 m_on_memory_write(uP_ADDR, DATA_IN());
@@ -169,15 +213,20 @@ void Z80RetroShield::Tick()
                 DATA_OUT(m_on_io_read(ADDR_L()));
             else
                 DATA_OUT(0);
+            debug_show_status("IOR : ");
         }
 
         // IO Write?
         if (!STATE_WR_N() && prevIORQ)
         {
+            debug_show_status("IOW : ");
             if (m_on_io_write != NULL)
                 m_on_io_write(ADDR_L(), DATA_IN());
         }
+
+        goto tick_tock;
     }
+    debug_show_status("    : ");
 
 tick_tock:
     prevIORQ = STATE_IORQ_N();
@@ -185,6 +234,7 @@ tick_tock:
     //////////////////////////////////////////////////////////////////////
     // start next cycle
     CLK_LOW();
+    debug_count_cycle();
 
     // natural delay for DATA Hold time (t_HR)
     DATA_DIR(DIR_IN);

--- a/src/z80retroshield.cpp
+++ b/src/z80retroshield.cpp
@@ -182,13 +182,13 @@ void Z80RetroShieldClassName::Tick(int cycles)
         // CLK goes high
         CLK_HIGH();
 
-        // Store the contents of the address-bus in case we're going to use it.
-        uP_ADDR = ADDR();
-
         //////////////////////////////////////////////////////////////////////
         // Memory Access?
         if (!STATE_MREQ_N())
             {
+                // Store the contents of the address-bus in case we're going to use it.
+                uP_ADDR = ADDR();
+
                 // RAM Read?
                 if (!STATE_RD_N())
                     {

--- a/src/z80retroshield.h
+++ b/src/z80retroshield.h
@@ -102,9 +102,9 @@ public:
     void Reset();
 
     /**
-     * Run a single cycle.
+     * Run specified cycles.
      */
-    void Tick();
+    void Tick(int cycles = 1);
 
     /**
      * Set the callback to be invoked when memory is to be read.

--- a/src/z80retroshield.h
+++ b/src/z80retroshield.h
@@ -28,6 +28,7 @@
 #ifndef _Z80RetroShield_DRIVER
 #define _Z80RetroShield_DRIVER 1
 
+// #define Z80RetroShield_DEBUG
 
 /**
  * Signatures for our callback functions.
@@ -47,6 +48,7 @@ typedef char (*memoryRead)(int address);
 typedef void (*memoryWrite)(int address, char byte);
 typedef char (*ioread)(int address);
 typedef void (*iowrite)(int address, char byte);
+typedef void (*debugOutput)(const char* msg);
 
 
 
@@ -142,6 +144,12 @@ public:
         m_on_io_write = cb;
     };
 
+    void set_debug_output(debugOutput cb)
+    {
+        m_debug_output = cb;
+        m_debug = true;
+    };
+
 
 private:
 
@@ -152,9 +160,27 @@ private:
     memoryWrite m_on_memory_write;
     ioread       m_on_io_read;
     iowrite      m_on_io_write;
+    debugOutput m_debug_output;
+    bool m_debug;
+    unsigned long m_cycle;
 
+    void show_status(const char* header);
+
+#ifdef Z80RetroShield_DEBUG
+    inline void debug_show_status(const char* header) {
+        if (m_debug)
+            show_status(header);
+    };
+
+    inline void debug_count_cycle(void) {
+        if (m_debug)
+            m_cycle++;
+    };
+#else
+    inline void debug_show_status(const char* header) { };
+    inline void debug_count_cycle(void) { };
+#endif
 
 };
-
 
 #endif /* _Z80RetroShield_DRIVER */

--- a/src/z80retroshield.h
+++ b/src/z80retroshield.h
@@ -25,33 +25,19 @@
 
 
 
-#ifndef _Z80RetroShield_DRIVER
+#if not defined(Z80RetroShield_DEBUG) && not defined(_Z80RetroShield_DRIVER) || \
+    defined(Z80RetroShield_DEBUG) && not defined(_Z80RetroShieldDebug_DRIVER)
+
+#ifdef Z80RetroShieldClassName
+#undef Z80RetroShieldClassName
+#endif
+#ifdef  Z80RetroShield_DEBUG
+#define Z80RetroShieldClassName Z80RetroShieldDebug
+#define _Z80RetroShieldDebug_DRIVER 1
+#else
+#define Z80RetroShieldClassName Z80RetroShield
 #define _Z80RetroShield_DRIVER 1
-
-// #define Z80RetroShield_DEBUG
-
-/**
- * Signatures for our callback functions.
- *
- * There are two callbacks for memory, and two for port-based I/O.
- *
- * You must provide the memory-read callback, otherwise the processor
- * will not be able to fetch instructions to execute, however the rest
- * are optional.
- *
- * It is suggested you allow writing to memory at least though, because
- * without the ability to write to memory things like the `call` instruction
- * will be broken - i.e. If you set the stack-pointer to 0x100 and a call
- * is made the return address will be pushed into that memory..
- */
-typedef char (*memoryRead)(int address);
-typedef void (*memoryWrite)(int address, char byte);
-typedef char (*ioread)(int address);
-typedef void (*iowrite)(int address, char byte);
-typedef void (*debugOutput)(const char* msg);
-
-
-
+#endif
 
 /**
  *
@@ -65,20 +51,40 @@ typedef void (*debugOutput)(const char* msg);
  * another pair of callbacks for handling port-based I/O.
  *
  */
-class Z80RetroShield
+class Z80RetroShieldClassName
 {
 
 public:
 
     /**
+     * Signatures for our callback functions.
+     *
+     * There are two callbacks for memory, and two for port-based I/O.
+     *
+     * You must provide the memory-read callback, otherwise the processor
+     * will not be able to fetch instructions to execute, however the rest
+     * are optional.
+     *
+     * It is suggested you allow writing to memory at least though, because
+     * without the ability to write to memory things like the `call` instruction
+     * will be broken - i.e. If you set the stack-pointer to 0x100 and a call
+     * is made the return address will be pushed into that memory..
+     */
+    typedef char (*memoryRead)(int address);
+    typedef void (*memoryWrite)(int address, char byte);
+    typedef char (*ioread)(int address);
+    typedef void (*iowrite)(int address, char byte);
+    typedef void (*debugOutput)(const char* msg);
+
+    /**
      * Constructor.
      */
-    Z80RetroShield();
+    Z80RetroShieldClassName();
 
     /**
      * Destructor.
      */
-    ~Z80RetroShield();
+    ~Z80RetroShieldClassName();
 
     /**
      * Reset the processor.

--- a/src/z80retroshield.h
+++ b/src/z80retroshield.h
@@ -76,6 +76,14 @@ public:
     typedef void (*iowrite)(int address, char byte);
     typedef void (*debugOutput)(const char* msg);
 
+    typedef unsigned int debugFlag;
+    static const debugFlag DEBUG_FLAG_IO = (1<<0);
+    static const debugFlag DEBUG_FLAG_MEM = (1<<1);
+    static const debugFlag DEBUG_FLAG_CYCLE = (1<<2);
+    static const debugFlag DEBUG_FLAG_VERBOSE = (1<<3);
+    static const debugFlag DEBUG_FLAG_TRACE_ALL =
+        (DEBUG_FLAG_IO|DEBUG_FLAG_MEM|DEBUG_FLAG_CYCLE|DEBUG_FLAG_VERBOSE);
+
     /**
      * Constructor.
      */
@@ -150,12 +158,29 @@ public:
         m_on_io_write = cb;
     };
 
+    /**
+     * Set the callback which handles some debug messages from the libraty.
+     */
     void set_debug_output(debugOutput cb)
     {
         m_debug_output = cb;
-        m_debug = true;
     };
 
+    /**
+     * Set debug flag(s)
+     */
+    void enable_debug(debugFlag flag)
+    {
+        m_debug |= flag;
+    };
+
+    /**
+     * Clear debug flag(s)
+     */
+    void disable_debug(debugFlag flag)
+    {
+        m_debug &= ~flag;
+    };
 
 private:
 
@@ -167,7 +192,7 @@ private:
     ioread       m_on_io_read;
     iowrite      m_on_io_write;
     debugOutput m_debug_output;
-    bool m_debug;
+    debugFlag m_debug;
     unsigned long m_cycle;
 
     void show_status(const char* header);

--- a/src/z80retroshieldDebug.cpp
+++ b/src/z80retroshieldDebug.cpp
@@ -1,0 +1,6 @@
+/*
+ * The z80retroshieldDebug class is almost identical to the z80retroshield.
+ * See z80retroshieldDebug.h
+ */
+#define Z80RetroShield_DEBUG
+#include "z80retroshield.cpp"

--- a/src/z80retroshieldDebug.h
+++ b/src/z80retroshieldDebug.h
@@ -1,0 +1,12 @@
+/*
+ * This z80retroshieldDebug class has some debugging features enabled that are
+ * conditionally compiled with #ifdef Z80RetroShield_DEBUG.
+ * The z80retroshieldDebug class is almost identical to the z80retroshield.
+ * Therefore, the source code .h and .cpp share the same file. The reason
+ * debugging functions are not enabled by inheritance and virtual functions is
+ * to prioritize the efficiency of Tick() execution.
+ */
+
+#define Z80RetroShield_DEBUG
+#include "z80retroshield.h"
+#undef Z80RetroShield_DEBUG

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,2 @@
+download
+.tmp*

--- a/test/arduino-cli-install.sh
+++ b/test/arduino-cli-install.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/other/installation-script/install.sh
+
+# The original version of this script (https://github.com/Masterminds/glide.sh/blob/master/get) is licensed under the
+# MIT license. See https://github.com/Masterminds/glide/blob/master/LICENSE for more details and copyright notice.
+
+PROJECT_OWNER="arduino"
+PROJECT_NAME="arduino-cli"
+
+# BINDIR represents the local bin location, defaults to ./bin.
+EFFECTIVE_BINDIR=""
+DEFAULT_BINDIR="$PWD/bin"
+
+fail() {
+  echo "$1"
+  exit 1
+}
+
+initDestination() {
+  if [ -n "$BINDIR" ]; then
+    if [ ! -d "$BINDIR" ]; then
+      # The second instance of $BINDIR is intentionally a literal in this message.
+      # shellcheck disable=SC2016
+      fail "$BINDIR "'($BINDIR)'" folder not found. Please create it before continuing."
+    fi
+    EFFECTIVE_BINDIR="$BINDIR"
+  else
+    if [ ! -d "$DEFAULT_BINDIR" ]; then
+      mkdir "$DEFAULT_BINDIR"
+    fi
+    EFFECTIVE_BINDIR="$DEFAULT_BINDIR"
+  fi
+  echo "Installing in $EFFECTIVE_BINDIR"
+}
+
+initArch() {
+  ARCH=$(uname -m)
+  case $ARCH in
+  armv5*) ARCH="armv5" ;;
+  armv6*) ARCH="ARMv6" ;;
+  armv7*) ARCH="ARMv7" ;;
+  aarch64) ARCH="ARM64" ;;
+  arm64) ARCH="ARM64" ;;
+  x86) ARCH="32bit" ;;
+  x86_64) ARCH="64bit" ;;
+  i686) ARCH="32bit" ;;
+  i386) ARCH="32bit" ;;
+  esac
+  echo "ARCH=$ARCH"
+}
+
+initFallbackArch() {
+  case "${OS}_${ARCH}" in
+  macOS_ARM64)
+    # Rosetta 2 allows applications built for x86-64 hosts to run on the ARM 64-bit M1 processor
+    FALLBACK_ARCH='64bit'
+    ;;
+  esac
+}
+
+initOS() {
+  OS=$(uname -s)
+  case "$OS" in
+  Linux*) OS='Linux' ;;
+  Darwin*) OS='macOS' ;;
+  MINGW*) OS='Windows' ;;
+  MSYS*) OS='Windows' ;;
+  esac
+  echo "OS=$OS"
+}
+
+initDownloadTool() {
+  if command -v "curl" >/dev/null 2>&1; then
+    DOWNLOAD_TOOL="curl"
+  elif command -v "wget" >/dev/null 2>&1; then
+    DOWNLOAD_TOOL="wget"
+  else
+    fail "You need curl or wget as download tool. Please install it first before continuing"
+  fi
+  echo "Using $DOWNLOAD_TOOL as download tool"
+}
+
+# checkLatestVersion() sets the CHECKLATESTVERSION_TAG variable to the latest version
+checkLatestVersion() {
+  # Use the GitHub releases webpage to find the latest version for this project
+  # so we don't get rate-limited.
+  CHECKLATESTVERSION_REGEX="[0-9][A-Za-z0-9\.-]*"
+  CHECKLATESTVERSION_LATEST_URL="https://github.com/${PROJECT_OWNER}/${PROJECT_NAME}/releases/latest"
+  if [ "$DOWNLOAD_TOOL" = "curl" ]; then
+    CHECKLATESTVERSION_TAG=$(curl -SsL $CHECKLATESTVERSION_LATEST_URL | grep -o "<title>Release $CHECKLATESTVERSION_REGEX · ${PROJECT_OWNER}/${PROJECT_NAME}" | grep -o "$CHECKLATESTVERSION_REGEX")
+  elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
+    CHECKLATESTVERSION_TAG=$(wget -q -O - $CHECKLATESTVERSION_LATEST_URL | grep -o "<title>Release $CHECKLATESTVERSION_REGEX · ${PROJECT_OWNER}/${PROJECT_NAME}" | grep -o "$CHECKLATESTVERSION_REGEX")
+  fi
+  if [ "$CHECKLATESTVERSION_TAG" = "" ]; then
+    echo "Cannot determine latest tag."
+    exit 1
+  fi
+}
+
+getFile() {
+  GETFILE_URL="$1"
+  GETFILE_FILE_PATH="$2"
+  if [ "$DOWNLOAD_TOOL" = "curl" ]; then
+    GETFILE_HTTP_STATUS_CODE=$(curl -s -w '%{http_code}' -L "$GETFILE_URL" -o "$GETFILE_FILE_PATH")
+  elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
+    wget --server-response --content-on-error -q -O "$GETFILE_FILE_PATH" "$GETFILE_URL"
+    GETFILE_HTTP_STATUS_CODE=$(awk '/^  HTTP/{print $2}' "$TMP_FILE")
+  fi
+  echo "$GETFILE_HTTP_STATUS_CODE"
+}
+
+downloadFile() {
+  if [ -z "$1" ]; then
+    checkLatestVersion
+    TAG="$CHECKLATESTVERSION_TAG"
+  else
+    TAG=$1
+  fi
+  #  arduino-lint_0.4.0-rc1_Linux_64bit.[tar.gz, zip]
+  APPLICATION_DIST_PREFIX="${PROJECT_NAME}_${TAG}_"
+  if [ "$OS" = "Windows" ]; then
+    APPLICATION_DIST_EXTENSION=".zip"
+  else
+    APPLICATION_DIST_EXTENSION=".tar.gz"
+  fi
+  APPLICATION_DIST="${APPLICATION_DIST_PREFIX}${OS}_${ARCH}${APPLICATION_DIST_EXTENSION}"
+
+  # Support specifying nightly build versions (e.g., "nightly-latest") via the script argument.
+  case "$TAG" in
+  nightly*)
+    DOWNLOAD_URL_PREFIX="https://downloads.arduino.cc/${PROJECT_NAME}/nightly/"
+    ;;
+  *)
+    DOWNLOAD_URL_PREFIX="https://downloads.arduino.cc/${PROJECT_NAME}/"
+    ;;
+  esac
+  DOWNLOAD_URL="${DOWNLOAD_URL_PREFIX}${APPLICATION_DIST}"
+
+  INSTALLATION_TMP_FILE="/tmp/$APPLICATION_DIST"
+  echo "Downloading $DOWNLOAD_URL"
+  httpStatusCode=$(getFile "$DOWNLOAD_URL" "$INSTALLATION_TMP_FILE")
+  if [ "$httpStatusCode" -ne 200 ]; then
+    if [ -n "$FALLBACK_ARCH" ]; then
+      echo "$OS $ARCH release not currently available. Checking for alternative $OS $FALLBACK_ARCH release for your system."
+      FALLBACK_APPLICATION_DIST="${APPLICATION_DIST_PREFIX}${OS}_${FALLBACK_ARCH}${APPLICATION_DIST_EXTENSION}"
+      DOWNLOAD_URL="${DOWNLOAD_URL_PREFIX}${FALLBACK_APPLICATION_DIST}"
+      echo "Downloading $DOWNLOAD_URL"
+      httpStatusCode=$(getFile "$DOWNLOAD_URL" "$INSTALLATION_TMP_FILE")
+    fi
+
+    if [ "$httpStatusCode" -ne 200 ]; then
+      echo "Did not find a release for your system: $OS $ARCH"
+      echo "Trying to find a release using the GitHub API."
+
+      LATEST_RELEASE_URL="https://api.github.com/repos/${PROJECT_OWNER}/$PROJECT_NAME/releases/tags/$TAG"
+      if [ "$DOWNLOAD_TOOL" = "curl" ]; then
+        HTTP_RESPONSE=$(curl -sL --write-out 'HTTPSTATUS:%{http_code}' "$LATEST_RELEASE_URL")
+        HTTP_STATUS_CODE=$(echo "$HTTP_RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+        BODY=$(echo "$HTTP_RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
+      elif [ "$DOWNLOAD_TOOL" = "wget" ]; then
+        TMP_FILE=$(mktemp)
+        BODY=$(wget --server-response --content-on-error -q -O - "$LATEST_RELEASE_URL" 2>"$TMP_FILE" || true)
+        HTTP_STATUS_CODE=$(awk '/^  HTTP/{print $2}' "$TMP_FILE")
+      fi
+      if [ "$HTTP_STATUS_CODE" != 200 ]; then
+        echo "Request failed with HTTP status code $HTTP_STATUS_CODE"
+        fail "Body: $BODY"
+      fi
+
+      # || true forces this command to not catch error if grep does not find anything
+      DOWNLOAD_URL=$(echo "$BODY" | grep 'browser_' | cut -d\" -f4 | grep "$APPLICATION_DIST") || true
+      if [ -z "$DOWNLOAD_URL" ]; then
+        DOWNLOAD_URL=$(echo "$BODY" | grep 'browser_' | cut -d\" -f4 | grep "$FALLBACK_APPLICATION_DIST") || true
+      fi
+
+      if [ -z "$DOWNLOAD_URL" ]; then
+        echo "Sorry, we dont have a dist for your system: $OS $ARCH"
+        fail "You can request one here: https://github.com/${PROJECT_OWNER}/$PROJECT_NAME/issues"
+      else
+        echo "Downloading $DOWNLOAD_URL"
+        getFile "$DOWNLOAD_URL" "$INSTALLATION_TMP_FILE"
+      fi
+    fi
+  fi
+}
+
+installFile() {
+  INSTALLATION_TMP_DIR="/tmp/$PROJECT_NAME"
+  mkdir -p "$INSTALLATION_TMP_DIR"
+  if [ "$OS" = "Windows" ]; then
+    unzip -d "$INSTALLATION_TMP_DIR" "$INSTALLATION_TMP_FILE"
+  else
+    tar xf "$INSTALLATION_TMP_FILE" -C "$INSTALLATION_TMP_DIR"
+  fi
+  INSTALLATION_TMP_BIN="$INSTALLATION_TMP_DIR/$PROJECT_NAME"
+  cp "$INSTALLATION_TMP_BIN" "$EFFECTIVE_BINDIR"
+  rm -rf "$INSTALLATION_TMP_DIR"
+  rm -f "$INSTALLATION_TMP_FILE"
+}
+
+bye() {
+  BYE_RESULT=$?
+  if [ "$BYE_RESULT" != "0" ]; then
+    echo "Failed to install $PROJECT_NAME"
+  fi
+  exit $BYE_RESULT
+}
+
+testVersion() {
+  set +e
+  if EXECUTABLE_PATH="$(command -v $PROJECT_NAME)"; then
+    # Convert to resolved, absolute paths before comparison
+    EXECUTABLE_REALPATH="$(cd -- "$(dirname -- "$EXECUTABLE_PATH")" && pwd -P)"
+    EFFECTIVE_BINDIR_REALPATH="$(cd -- "$EFFECTIVE_BINDIR" && pwd -P)"
+    if [ "$EXECUTABLE_REALPATH" != "$EFFECTIVE_BINDIR_REALPATH" ]; then
+      # $PATH is intentionally a literal in this message.
+      # shellcheck disable=SC2016
+      echo "An existing $PROJECT_NAME was found at $EXECUTABLE_PATH. Please prepend \"$EFFECTIVE_BINDIR\" to your "'$PATH'" or remove the existing one."
+    fi
+  else
+    # $PATH is intentionally a literal in this message.
+    # shellcheck disable=SC2016
+    echo "$PROJECT_NAME not found. You might want to add \"$EFFECTIVE_BINDIR\" to your "'$PATH'
+  fi
+
+  set -e
+  APPLICATION_VERSION="$("$EFFECTIVE_BINDIR/$PROJECT_NAME" version)"
+  echo "$APPLICATION_VERSION installed successfully in $EFFECTIVE_BINDIR"
+}
+
+# Execution
+
+#Stop execution on any error
+trap "bye" EXIT
+initDestination
+set -e
+initArch
+initOS
+initFallbackArch
+initDownloadTool
+downloadFile "$1"
+installFile
+testVersion

--- a/test/arduino-cli.yaml
+++ b/test/arduino-cli.yaml
@@ -1,0 +1,23 @@
+board_manager:
+  additional_urls:
+  - https://adafruit.github.io/arduino-board-index/package_adafruit_index.json
+daemon:
+  port: "50051"
+directories:
+  data: download/Arduino15
+  downloads: download/Arduino15/staging
+  user: download/Arduino15
+ide:
+  bundled: false
+  portable: false
+library:
+  enable_unsafe_install: false
+logging:
+  file: ""
+  format: text
+  level: info
+metrics:
+  addr: :9090
+  enabled: true
+sketch:
+  always_export_binaries: false

--- a/test/board_test.sh
+++ b/test/board_test.sh
@@ -67,6 +67,17 @@ run_tests() {
        expect -re "Hello, world! .*100.*\r"
     '
 
+    test "Hello Debug" $examples/hello-debug '
+       expect "Z80 configured; launching program.\r"
+       expect "IOW : *\[0-9\]* addr=4801 data=0048 ~MREQ=H ~IOREQ=L  RW="
+       expect "IOW : *\[0-9\]* addr=6501 data=0065 ~MREQ=H ~IOREQ=L  RW="
+       expect "IOW : *\[0-9\]* addr=6c01 data=006c ~MREQ=H ~IOREQ=L  RW="
+       expect "IOW : *\[0-9\]* addr=6c01 data=006c ~MREQ=H ~IOREQ=L  RW="
+       expect "IOW : *\[0-9\]* addr=6f01 data=006f ~MREQ=H ~IOREQ=L  RW="
+       expect "IOW : *\[0-9\]* addr=0a01 data=000a ~MREQ=H ~IOREQ=L  RW="
+       expect -re "Z80 processor stopped \[0-9\]* cycles executed.\r"
+    '
+
     test "Speed test" $examples/speed_test '
        expect "Z80 configured to run endless stream of NOPs.\r"
        for {set i 1} {$i <= 10} {incr i 1} {

--- a/test/board_test.sh
+++ b/test/board_test.sh
@@ -69,12 +69,11 @@ run_tests() {
 
     test "Hello Debug" $examples/hello-debug '
        expect "Z80 configured; launching program.\r"
-       expect "IOW : *\[0-9\]* addr=4801 data=0048 ~MREQ=H ~IOREQ=L  RW="
-       expect "IOW : *\[0-9\]* addr=6501 data=0065 ~MREQ=H ~IOREQ=L  RW="
-       expect "IOW : *\[0-9\]* addr=6c01 data=006c ~MREQ=H ~IOREQ=L  RW="
-       expect "IOW : *\[0-9\]* addr=6c01 data=006c ~MREQ=H ~IOREQ=L  RW="
-       expect "IOW : *\[0-9\]* addr=6f01 data=006f ~MREQ=H ~IOREQ=L  RW="
-       expect "IOW : *\[0-9\]* addr=0a01 data=000a ~MREQ=H ~IOREQ=L  RW="
+       expect "IOW : *\[0-9\]* addr=4801 data=48 ~MREQ=H ~IOREQ=L  RW="
+       expect "IOW : *\[0-9\]* addr=6501 data=65 ~MREQ=H ~IOREQ=L  RW="
+       expect "IOW : *\[0-9\]* addr=6c01 data=6c ~MREQ=H ~IOREQ=L  RW="
+       expect "IOW : *\[0-9\]* addr=6f01 data=6f ~MREQ=H ~IOREQ=L  RW="
+       expect "IOW : *\[0-9\]* addr=0a01 data=0a ~MREQ=H ~IOREQ=L  RW="
        expect -re "Z80 processor stopped \[0-9\]* cycles executed.\r"
     '
 

--- a/test/board_test.sh
+++ b/test/board_test.sh
@@ -1,0 +1,379 @@
+#!/bin/bash -eu
+
+# z80retroshield automated test suite
+# Author: hanyazou@gmail.com
+
+run_tests() {
+    if ! prepair; then
+        return
+    fi
+    local examples=$ROOTDIR/examples
+
+    test Hello $examples/hello '
+       expect "Z80 configured; launching program.\r"
+       expect "Hello\r"
+       expect -re "Z80 processor stopped \[0-9\]* cycles executed.\r"
+    '
+
+    test "RAM test" $examples/ram-test '
+       expect "Z80 configured; launching program.\r"
+       expect "RAM \\\[ 21 08 00 7E 3C 77 18 FB 00 \\\]  counter value: 0\r"
+       expect "RAM \\\[ 21 08 00 7E 3C 77 18 FB 01 \\\]  counter value: 1\r"
+       expect "RAM \\\[ 21 08 00 7E 3C 77 18 FB 02 \\\]  counter value: 2\r"
+       expect -re "Z80 processor stopped \[0-9\]* cycles executed.\r"
+    '
+
+    test --send-lf Monitor $examples/monitor '
+       expect "Z80 configured; launching program.\r"
+       expect ">"
+       send "D0000\r"
+       expect "0000 31 FB 00 3E 3E D3 01 21 FB 00 36 0A DB 01 77 FE\r"
+       expect ">"
+       send "I0200 3E 4F D3 01 3E 4B D3 01 3E 0A D3 01 C9\r"
+       expect ">"
+       send "D0200\r"
+       expect "0200 3E 4F D3 01 3E 4B D3 01 3E 0A D3 01 C9 00 00 00\r"
+       expect ">"
+       send "C0200\r"
+       expect "OK\r"
+       expect ">"
+    '
+
+    test --send-lf "Upper Case conv" $examples/uc '
+       expect "Z80 configured; launching program.\r"
+       expect ">"
+       send "Hello, world!\r"
+       expect "HELLO, WORLD!\r"
+       send "Bye!\r"
+       expect "BYE!\r"
+    '
+
+    test "Run basic" $examples/basic '
+       expect "Memory top? "
+       send "0\r"
+       expect {
+           "Ok\r" { }
+           "Memory top? " {
+               send "\r"
+               expect "Ok\r"
+           }
+       }
+       
+       send "10 A=0:FOR I=1 TO 100:A=A+1:NEXT:PRINT A\r"
+       send "RUN\r"
+       expect -re ".*100.*\r"
+       expect "Ok\r"
+       send "PRINT \"Hello, world!\", A\r"
+       expect -re "Hello, world! .*100.*\r"
+    '
+
+    test "Speed test" $examples/speed_test '
+       expect "Z80 configured to run endless stream of NOPs.\r"
+       for {set i 1} {$i <= 10} {incr i 1} {
+           expect -re "Cycles per second second:\[0-9\]*\r"
+       }
+    '
+}
+
+usage()
+{
+    echo "boad_test [options] [commands]"
+    echo "command:"
+    echo "        cleanup delete downloaded packages"
+    echo "           list list all test names"
+    echo "option:"
+    echo "  --run <names> run specified test only (use ',' for multiple names)"
+    echo "--board <names> run specified board only (use ',' for multiple names)"
+    echo "   --repeat <n> run each test for specified number of times"
+    echo "  --no-download skip downloading packages"
+    echo "      --verbose enable verbose output"
+    echo "         --help display this message"
+}
+
+main()
+{
+    setup
+
+    local done=false
+    while (( $# > 0 )); do
+        case "$1" in
+        cleanup)
+            cleanup
+            done=true
+            ;;
+        list)
+            opt_list_targets=true
+            echo test names:
+            run_tests
+            done=true
+            ;;
+        -t|--run)
+            shift
+            opt_target_cases+=( $( echo "$1" | tr '[:upper:],' '[:lower:] ' ) )
+            opt_target_case_specified=true
+            ;;
+        -b|--board)
+            shift
+            opt_target_boards+=( $( echo "$1" | tr '[:upper:],' '[:lower:] ' ) )
+            opt_target_board_specified=true
+            ;;
+        -n|--repeat)
+            shift
+            opt_repeat_count="$1"
+            ;;
+        --no-download)
+            opt_no_download=true
+            ;;
+        -v|--verbose)
+            opt_verbose=true
+            ;;
+        -h|--help)
+            usage
+            done=true
+            ;;
+        -*)
+            echo unknown option "'"$1"'"
+            usage
+            exit 1
+            ;;
+        *)
+            echo invalid argument "'"$1"'"
+            usage
+            exit 1
+            ;;
+        esac
+        shift
+    done
+
+    if $done; then
+        exit 0
+    fi
+
+    if ! $opt_no_download; then
+        download
+    fi
+
+    TGT_FQBN=arduino:avr:mega
+    run_tests
+
+    echo
+    cat  .tmp.summary
+    echo
+    printf "  executed %d tests, %d failures\n" $TTL_COUNT $TTL_FAILURES
+    if [ "$TTL_COUNT" != 0 ] && [ "$TTL_FAILURES" == 0 ]; then
+        highlight ".  Succeeded"
+        exit 0
+    else
+        highlight ".  FAILED"
+        exit 1
+    fi
+}
+
+setup() {
+    ROOTDIR=..
+    opt_list_targets=false
+    opt_target_cases=( )
+    opt_target_case_specified=false
+    opt_target_boards=( )
+    opt_target_board_specified=false
+    opt_repeat_count=1
+    opt_no_download=false
+    opt_verbose=false
+
+    TTL_COUNT=0
+    TTL_FAILURES=0
+    rm -f .tmp*
+    echo -n > .tmp.summary
+}
+
+download() {
+    if [ ! -e ./download/bin/arduino-cli ]; then
+        mkdir -p ./download/bin
+        BINDIR=./download/bin sh arduino-cli-install.sh 0.29.0
+    fi
+    mkdir -p ./download/Arduino15/libraries
+    ln -sf $project_dir ./download/Arduino15/libraries/
+    
+    arduino-cli core update-index
+    arduino-cli core install arduino:avr@1.8.6
+}
+
+prepair() {
+    if $opt_list_targets; then
+        return 0
+    fi
+    if ! check_target_board $TGT_FQBN; then
+        return 1
+    fi
+
+    echo Using $( arduino-cli version )
+    echo "      $( which arduino-cli )"
+
+    ACLI_OPTS=""
+    ACLI_OPTS+=" --config-file ./arduino-cli.yaml"
+    if $opt_verbose; then
+        ACLI_OPTS+=" --verbose"
+    fi
+
+    TGT_PORT=$( arduino-cli board list | grep -e $TGT_FQBN | grep -e '^/dev/' | awk '{ print $1 }' )
+    if [ "$TGT_PORT" != "" ]; then
+        echo "Board $TGT_FQBN is found at port $TGT_PORT"
+    else
+        echo "Board $TGT_FQBN is not found"
+    fi
+
+    return 0
+}
+
+test() {
+    local res=N/A
+    local send_return_code=--send-cr
+
+    while (( $# > 0 )); do
+        case "$1" in
+        --send-cr|--send-lf)
+            send_return_code=$1
+            shift
+            ;;
+        -*)
+            echo unknown option "'"$1"'"
+            return 1
+            ;;
+        *)
+            break
+            ;;
+        esac
+    done
+
+    local name="$1"
+    local sketch="$2"
+    local expect="$3"
+
+    if $opt_list_targets; then
+        echo "    $( echo "$name" | tr '[:upper:] ' '[:lower:]_' )"
+        return
+    fi
+
+    if ! check_target_case "$name"; then
+        return
+    fi
+
+    echo arduino-cli compile $ACLI_OPTS --fqbn $TGT_FQBN $sketch
+    arduino-cli compile $ACLI_OPTS --fqbn $TGT_FQBN $sketch
+
+    if [ "$TGT_PORT" == "" ]; then
+        _test "$name"
+        return
+    fi
+    
+    local mon_opts="$ACLI_OPTS --fqbn $TGT_FQBN --port $TGT_PORT --config baudrate=115200"
+    echo '#!/usr/bin/expect
+          set timeout 20
+          expect_before {
+              timeout { puts "Timeout detected"; exit 2 }
+              eof     { puts "Unexpected EOD";   exit 1 }
+          }
+          '"spawn ./serial-monitor-wrapper $send_return_code " \
+              "arduino-cli monitor $mon_opts $expect" > .tmp.exp
+
+    local count
+    for count in $( seq $opt_repeat_count ); do
+        echo arduino-cli upload $ACLI_OPTS --fqbn $TGT_FQBN --port $TGT_PORT --verify $sketch
+        arduino-cli upload $ACLI_OPTS --fqbn $TGT_FQBN --port $TGT_PORT --verify $sketch
+
+        if expect .tmp.exp; then
+            res=pass
+        else
+            res=FAIL
+            TTL_FAILURES=$(( TTL_FAILURES + 1 ))
+        fi
+
+        TTL_COUNT=$(( TTL_COUNT + 1 ))
+
+        local log="$( printf "  %s %-20s %s" $res "$name" $TGT_FQBN)"
+        highlight ".$log"
+        echo $TTL_FAILURES failures / $TTL_COUNT executions
+        echo "$log" >> .tmp.summary
+    done
+    rm .tmp.exp
+}
+
+_test() {
+    while (( $# > 0 )); do
+        case "$1" in
+        -*)
+            shift
+            ;;
+        *)
+            break
+            ;;
+        esac
+    done
+
+    local name="$1"
+    if $opt_list_targets; then
+        echo "    $( echo "$name" | tr '[:upper:] ' '[:lower:]_' )"
+        return
+    fi
+
+    if ! check_target_case "$name"; then
+        return
+    fi
+    local log="$( printf "  %s %-20s %s" skip "$name" $TGT_FQBN)"
+    highlight ".$log"
+    echo "$log" >> .tmp.summary
+}
+
+check_target_case()
+{
+    if ! $opt_target_case_specified; then
+        return 0
+    fi
+    
+    local name=$( echo "$1" | tr '[:upper:] ' '[:lower:]_' )
+    local result=1
+    for test in "${opt_target_cases[@]}"; do
+        if [ "${name}" == "${test%h}" ]; then
+            result=0
+            break
+        fi
+    done
+
+    return $result
+}
+
+check_target_board()
+{
+    if ! $opt_target_board_specified; then
+        return 0
+    fi
+    
+    local name="$1"
+    local result=1
+    for board in "${opt_target_boards[@]}"; do
+        if [ "${name}" == "${board}" ]; then
+            result=0
+            break
+        fi
+    done
+
+    return $result
+}
+
+cleanup() {
+    rm -rf download
+    rm -rf .tmp*
+}
+
+highlight() {
+    echo ==============================
+    echo "$*" | sed -e 's/^.//'
+    echo ==============================
+}
+
+export PATH=./download/bin:$PATH
+project_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && cd .. && pwd )"
+cd $project_dir/test
+
+main $*
+

--- a/test/serial-monitor-wrapper
+++ b/test/serial-monitor-wrapper
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+send_return_code=$(printf '\r')
+
+while (( $# > 0 )); do
+    case "$1" in
+    --send-cr)
+        send_return_code=$(printf '\r')
+        shift
+        echo $0: send CR
+        ;;
+    --send-lf)
+        send_return_code=$(printf '\n')
+        shift
+        echo $0: send LF
+        ;;
+    -*)
+        echo unknown option "'"$1"'"
+        exit 1
+        ;;
+    *)
+        break
+        ;;
+    esac
+done
+
+sed -u -e "s/$/$send_return_code/g" | $*


### PR DESCRIPTION
This PR contains these changes bellow.

* Minor bug fixes
  7cfdba4 Fix speed_test, use long type for the cycle counter
  2f2798f Fix minor errors like type mismatch in examples

* A test script which compile, upload and run all examples
  e16b3f9 Add automated test suite

* Replace #define macros with static inline functions
This change allows to implement board support in the inline functions
This change does not affects the result of the speed test example
  f4c6243 Replace #define macros with static inline functions

* Add a debugging function which traces memory and IO access
  34f7fb3 Add dump_debug_info()
  bf7be07 Add z80retroshieldDebug class
  4231e38 Add enable_debug() / disable_debug()

* Optimizations
These changes increase the result of the speed test example from 120K to 420K
  4611753 Add internal loop in Tick() for optimization
  5c64fab Read the address only if MREQ or IORQ is asserted
